### PR TITLE
Update freedesktop sdk to 25.08

### DIFF
--- a/org.racket_lang.Racket.yml
+++ b/org.racket_lang.Racket.yml
@@ -1,6 +1,6 @@
 app-id: org.racket_lang.Racket
 runtime: org.freedesktop.Platform
-runtime-version: '23.08'
+runtime-version: '25.08'
 sdk: org.freedesktop.Sdk
 command: drracket
 rename-desktop-file: drracket.desktop


### PR DESCRIPTION
Freedesktop 23.08 is showing an EOL warning where racket is installing.

Updating to 25.08 does not seem to break anything.